### PR TITLE
Fixed ASG uniform texture issue on respawn introduced in #13

### DIFF
--- a/onPlayerRespawn.sqf
+++ b/onPlayerRespawn.sqf
@@ -1,4 +1,7 @@
-if (player getVariable ["BIS_revive_incapacitated", false]) exitWith { true };
+if (player getVariable ["BIS_revive_incapacitated", false]) exitWith {
+	[[player], "ASG_fnc_setUniform", nil, true, true] call BIS_fnc_MP;
+	true;
+};
 
 // Equip Player with ASG Equipment
 [player] call ASG_fnc_equipPlayer;


### PR DESCRIPTION
Quick fix; updating textures should be global and don't need to use BIS_fnc_MP but timing issues with respawning units make this "easiest".